### PR TITLE
Traffic-Filter and Policy-List Patterns

### DIFF
--- a/syntaxes/cisco.tmLanguage.json
+++ b/syntaxes/cisco.tmLanguage.json
@@ -508,6 +508,9 @@
 				},
 				{
 					"include": "#pool"
+				},
+				{
+					"include": "#policy-list"
 				}
 			],
 			"repository": {
@@ -549,6 +552,10 @@
 				"pool": {
 					"match": "(?<=\\bpool\\s)(\\S+)\\b",
 					"name": "entity.name.tag.group.pool.name.cisco"
+				},
+				"policy-list": {
+					"match": "(?<=policy-list\\s)(\\S+)\\b",
+					"name": "entity.name.tag.group.policy-list.name.cisco"
 				}
 			}
 		},

--- a/syntaxes/cisco.tmLanguage.json
+++ b/syntaxes/cisco.tmLanguage.json
@@ -511,6 +511,9 @@
 				},
 				{
 					"include": "#policy-list"
+				},
+				{
+					"include": "#traffic-filter"
 				}
 			],
 			"repository": {
@@ -556,6 +559,10 @@
 				"policy-list": {
 					"match": "(?<=policy-list\\s)(\\S+)\\b",
 					"name": "entity.name.tag.group.policy-list.name.cisco"
+				},
+				"traffic-filter": {
+					"match": "(?<=traffic-filter\\s)(\\S+)\\b",
+					"name": "entity.name.tag.group.traffic-filter.name.cisco"
 				}
 			}
 		},

--- a/syntaxes/cisco.tmLanguage.json
+++ b/syntaxes/cisco.tmLanguage.json
@@ -514,6 +514,9 @@
 				},
 				{
 					"include": "#traffic-filter"
+				},
+				{
+					"include": "#community"
 				}
 			],
 			"repository": {
@@ -563,6 +566,10 @@
 				"traffic-filter": {
 					"match": "(?<=traffic-filter\\s)(\\S+)\\b",
 					"name": "entity.name.tag.group.traffic-filter.name.cisco"
+				},
+				"community": {
+					"match": "(?<=community\\s)(\\S+)\\b",
+					"name": "entity.name.tag.group.community.name.cisco"
 				}
 			}
 		},


### PR DESCRIPTION
From the conversation in [PR13](https://github.com/Y-Ysss/vscode-cisco-config-highlight/pull/13), I have branched from upstream/develop-v0.6 and added the patterns for `traffic-filter`, `policy-list`, and `community`.

<img width="347" alt="image" src="https://github.com/user-attachments/assets/f48609a8-e568-4fea-b2f8-16f1ec2a9903" />
