### PR TITLE
fix: add handling for static-route control commands in IP prefix vali…

### DIFF
--- a/src/providers/diagnostics/rules/ipPrefix.test.ts
+++ b/src/providers/diagnostics/rules/ipPrefix.test.ts
@@ -55,6 +55,15 @@ describe('scanIpPrefixFindings', () => {
   });
 
   it.each([
+    'ip route static inter-vrf',
+    'ip route static adjust-time 60',
+    'ip route static aadjust-time 60',
+    'no ip route static inter-vrf',
+  ])('ignores static-route control commands: %s', (line) => {
+    expect(scanIpPrefixFindings(source(line))).toEqual([]);
+  });
+
+  it.each([
     [
       'ip route 2.0.0.0 0.0.0.0 192.168.1.1',
       '2.0.0.0 0.0.0.0',

--- a/src/providers/diagnostics/rules/ipPrefix.ts
+++ b/src/providers/diagnostics/rules/ipPrefix.ts
@@ -342,6 +342,7 @@ const validateCandidate = (
   if (!tokens[2] || !tokens[3]) return false;
   const addressKeyword = lower(tokens[2]);
   if (
+    (lower(tokens[1]) === 'route' && addressKeyword === 'static') ||
     addressKeyword === 'vrf' ||
     addressKeyword === 'dhcp' ||
     addressKeyword === 'negotiated' ||


### PR DESCRIPTION
This pull request updates the static route IP prefix diagnostics to improve accuracy by ignoring control commands and refining candidate validation logic. The main focus is to prevent false positives when scanning for static route findings.

### Improvements to static route command handling:

* Updated `scanIpPrefixFindings` to ignore static-route control commands such as `ip route static inter-vrf` and related variants, ensuring these lines are not incorrectly flagged.
* Enhanced `validateCandidate` in `ipPrefix.ts` to explicitly skip lines where the third token is `static` after `ip route`, preventing misclassification of non-route commands as route definitions.